### PR TITLE
Feat: Organisms/FileField component creation

### DIFF
--- a/src/Components/Atoms/DatePickerInput/DatePickerInput.stories.tsx
+++ b/src/Components/Atoms/DatePickerInput/DatePickerInput.stories.tsx
@@ -17,12 +17,15 @@ const Template: ComponentStory<typeof DatePickerInput> = ({ inputValue, ...args 
   const [date, setDate] = useState<Date | null>(inputValue ? inputValue : null);
 
   useEffect(() => {
-    setLoading(true);
     const loadLocale = async () => {
-      if (args.locale)
-        await importFnsLocaleFile(args.locale).finally(() => {
-          setLoading(false);
-        });
+      setLoading(true);
+      if (args.locale) {
+        await importFnsLocaleFile(args.locale)
+          .catch(console.error)
+          .finally(() => {
+            setLoading(false);
+          });
+      }
     };
 
     loadLocale();

--- a/src/Components/Atoms/FileInput/FileInput.tsx
+++ b/src/Components/Atoms/FileInput/FileInput.tsx
@@ -9,14 +9,14 @@ import FileGallery from './FileGallery';
 export interface IFileInputProps {
   /** Accepted types (optional, default: '\*\/\*') */
   acceptTypes?: string;
+  /** Class for the input (optional, default: undefined) */
+  className?: string;
   /** For test purpose only */
   dataTestId?: string;
   /** Disabled field (optional, default: false) */
   disabled?: boolean;
   /** Size of the field in a 12 column grid (optional, default: undefined) */
   fieldSize?: number;
-  /** Class for the input (optional, default: undefined) */
-  inputClassName?: string;
   /** Initial values for the field (optional, default: []) */
   inputValue?: Array<IFile>;
   /** Field is in error state (optiona, default: false) */
@@ -76,10 +76,10 @@ const unhighlight = (event: DragEvent) => {
 const FileInput = (props: IFileInputProps): ReactElement => {
   const {
     acceptTypes,
+    className,
     dataTestId,
     disabled,
     fieldSize,
-    inputClassName,
     inputValue,
     isInError,
     maxFiles,
@@ -358,7 +358,7 @@ const FileInput = (props: IFileInputProps): ReactElement => {
 
   return (
     <div
-      className={classnames('file-input-container', inputClassName, fieldSize && `field-input-size-${fieldSize}`)}
+      className={classnames('file-input-container', className, fieldSize && `field-input-size-${fieldSize}`)}
       style={style}>
       <div
         key='droparea'

--- a/src/Components/Atoms/FileInput/index.ts
+++ b/src/Components/Atoms/FileInput/index.ts
@@ -1,0 +1,4 @@
+export { default as FileInput } from './FileInput';
+export { formatBytes } from './fileUtils';
+export { FileStatusEnum } from './types';
+export type { IFile } from './types';

--- a/src/Components/Atoms/FileInput/types.ts
+++ b/src/Components/Atoms/FileInput/types.ts
@@ -20,9 +20,9 @@ export interface IFile {
   type: string;
   /** Status of the file (optional, if not provided, will be automatically set to FileStatusEnum.DONE) */
   status?: FileStatusEnum;
-  /** Progress of the upload, meaningfull while status is FileStatusEnum.UPLOADING */
+  /** Progress of the upload, meaningful while status is FileStatusEnum.UPLOADING */
   progress?: number;
-  /** Error message of the upload, meaningfull while status is FileStatusEnum.ERROR */
+  /** Error message of the upload, meaningful while status is FileStatusEnum.ERROR */
   error?: string;
   /** Result provided by the upload call
    * (usually as a string, which might need to be parsed, for example using JSON.parse) */

--- a/src/Components/Atoms/index.ts
+++ b/src/Components/Atoms/index.ts
@@ -2,6 +2,7 @@ export * from './AmountInput';
 export * from './Badge';
 export * from './CheckBoxInput';
 export * from './DatePickerInput';
+export * from './FileInput';
 export * from './GenericField';
 export * from './Icon';
 export * from './Layout';

--- a/src/Components/Molecules/AmountField/AmountField.tsx
+++ b/src/Components/Molecules/AmountField/AmountField.tsx
@@ -6,7 +6,7 @@ import { GenericField, AmountInput, ThousandsGroupStyle } from '../../Atoms';
 export interface IAmountFieldProps {
   /** Allows negative values (optional, default: true) */
   allowNegative?: boolean;
-  /** REact Container ref (optional, default: undefined) */
+  /** React Container ref (optional, default: undefined) */
   containerRef?: Ref<HTMLDivElement>;
   /** For test purpose only */
   dataTestId?: string;
@@ -63,7 +63,7 @@ export interface IAmountFieldProps {
 /**
  * Amount field component
  *
- * Date picker input wrapped in a generic field ( @see GenericField ).
+ * Amount picker input wrapped in a generic field ( @see GenericField ).
  *
  * Calls @param onChange for every input change.
  *

--- a/src/Components/Molecules/DatePickerField/DatePickerField.stories.tsx
+++ b/src/Components/Molecules/DatePickerField/DatePickerField.stories.tsx
@@ -10,16 +10,19 @@ export default {
 } as ComponentMeta<typeof DatePickerField>;
 
 const Template: ComponentStory<typeof DatePickerField> = ({ inputValue, ...args }: IDatePickerFieldProps) => {
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [localValue, setLocalValue] = useState<Date | null | undefined>(inputValue);
 
   useEffect(() => {
-    setLoading(true);
     const loadLocale = async () => {
-      if (args.locale)
-        await importFnsLocaleFile(args.locale).finally(() => {
-          setLoading(false);
-        });
+      if (args.locale) {
+        setLoading(true);
+        return await importFnsLocaleFile(args.locale)
+          .catch(console.error)
+          .finally(() => {
+            setLoading(false);
+          });
+      }
     };
 
     loadLocale();

--- a/src/Components/Molecules/FileField/FileField.stories.tsx
+++ b/src/Components/Molecules/FileField/FileField.stories.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { FileField, IFileFieldProps } from './FileField';
+import { FileStatusEnum, IFile } from '../../Atoms';
+
+export default {
+  title: 'Molecule/FileField',
+  component: FileField,
+  parameters: { controls: { sort: 'requiredFirst' } },
+} as ComponentMeta<typeof FileField>;
+
+const Template: ComponentStory<typeof FileField> = (args: IFileFieldProps) => {
+  return (
+    <FileField
+      {...args}
+      onChange={(file: Array<IFile>) => {
+        if (args.onChange) {
+          args.onChange(file);
+        }
+        return Promise.resolve();
+      }}
+      onDelete={(file: IFile) => {
+        if (args.onDelete) {
+          args.onDelete(file);
+        }
+        return Promise.resolve();
+      }}
+      onDownload={(file: IFile) => {
+        if (args.onDownload) {
+          args.onDownload(file);
+        }
+        return Promise.resolve();
+      }}
+    />
+  );
+};
+
+const commonProps = {
+  name: 'name',
+  maxFileSize: 10 * 1024 * 1024,
+  inputValue: [
+    { uid: '1', name: 'test file.png', size: 1234, type: 'image/png', status: FileStatusEnum.DONE },
+    { uid: '2', name: 'second test file.png', size: 1234, type: 'image/png', status: FileStatusEnum.DONE },
+    {
+      uid: '3',
+      name: 'third test file.png',
+      size: 1234,
+      type: 'image/png',
+      status: FileStatusEnum.ERROR,
+      error: 'Error message',
+    },
+  ],
+  onChange: () => {
+    return;
+  },
+  onDelete: () => {
+    return Promise.resolve();
+  },
+  onDownload: () => {
+    return Promise.resolve();
+  },
+  requestMethod: 'POST',
+  requestUrl: 'https://file-upload-tester.herokuapp.com/upload/file',
+  showProgressBar: true,
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  label: 'File field',
+  ...commonProps,
+};
+
+export const ReadOnly = Template.bind({});
+ReadOnly.args = {
+  label: 'File field in read only',
+  readOnly: true,
+  ...commonProps,
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  label: 'File field in error with label size = 4 and field size = 4',
+  errorMessage: 'This file fied is on error',
+  fieldSize: 4,
+  labelSize: 4,
+  ...commonProps,
+};
+
+export const HelperAndLimit = Template.bind({});
+HelperAndLimit.args = {
+  label: 'File field with helper',
+  helperText: 'Helper text',
+  additionalInfo: <div>This is addition info Element</div>,
+  mandatory: true,
+  ...commonProps,
+};
+
+export const Highlighted = Template.bind({});
+Highlighted.args = {
+  label: 'File field highlighted',
+  readOnly: true,
+  highlighted: true,
+  helperText: 'Helper text',
+  ...commonProps,
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  label: 'File field disabled',
+  disabled: true,
+  helperText: 'Helper text',
+  ...commonProps,
+};

--- a/src/Components/Molecules/FileField/FileField.tsx
+++ b/src/Components/Molecules/FileField/FileField.tsx
@@ -1,0 +1,190 @@
+import React, { CSSProperties, ReactElement, Ref } from 'react';
+
+import { GenericField, FileInput, IFile } from '../../Atoms';
+
+export interface IFileFieldProps {
+  /** Accepted types (optional, default: '\*\/\*') */
+  acceptTypes?: string;
+  /** Additional information (options, default: undefined) */
+  additionalInfo?: string | ReactElement;
+  /** React Container ref (optional, default: undefined) */
+  containerRef?: Ref<HTMLDivElement>;
+  /** For test purpose only */
+  dataTestId?: string;
+  /** Disabled field (optional, default: false) */
+  disabled?: boolean;
+  /** Error message (optional, default: undefined) */
+  errorMessage?: string;
+  /** Class for the field surrounding the input (optional, default: undefined) */
+  fieldClassName?: string;
+  /** Size of the field in a 12 column grid (optional, default: undefined) */
+  fieldSize?: number;
+  /** Helper text (optional, default: undefined) */
+  helperText?: string;
+  /** Highlighted field (optional, default: false) */
+  highlighted?: boolean;
+  /** Inline field (optional, default: false) */
+  inline?: boolean;
+  /** Class for the input (optional, default: undefined) */
+  inputClassName?: string;
+  /** Input number value (optional, default: undefined) */
+  inputValue?: Array<IFile>;
+  /** Label (optional, default: undefined) */
+  label?: string;
+  /** Size of the field in a 12 column grid (optional, default: undefined) */
+  labelSize?: number;
+  /** Mandatory field (optional, default: false) */
+  mandatory?: boolean;
+  /** Maximum number of files, if undefined: unlimited (optional, default: undefined) */
+  maxFiles?: number;
+  /** Maximum file size allowed in bytes, if undefined: unlimited (optional, default: undefined) */
+  maxFileSize?: number;
+  /** Maximum folder depth scanned when dropping a folder (optional, default: 2) */
+  maxFolderDepth?: number;
+  /** Name of text field */
+  name: string;
+  /** handler of changes, notifying any files changes (including new files, states changes, deleted files...)
+   * To retrieve the up to date files, simply filter the files on the status FileStatusEnum.DONE */
+  onChange: (files: Array<IFile>) => void;
+  /** Handler of the download request
+   * The promise should reject if the deletion fails. */
+  onDelete: (file: IFile) => Promise<void>;
+  /** Handler of download request
+   * The client should let the user know if the download fails.
+   * Promise resolution or rejection will only prevent multiple downloads of the same file. */
+  onDownload?: (file: IFile) => Promise<void>;
+  /** Read only field (optional, default: false) */
+  readOnly?: boolean;
+  /** Extra header (optional, default: undefined) */
+  requestHeaders?: Record<string, string>;
+  /** HTTP method used for the upload (optional, default: 'POST' ) */
+  requestMethod: 'POST' | 'PUT';
+  /** Url of the request */
+  requestUrl: string;
+  /** Enable withCredentials on the request (optional, default: undefined) */
+  requestWithCredentials?: boolean;
+  /** Show file size in the gallery (optional, default: false) */
+  showFileSize?: boolean;
+  /** Show progress bar in file gallery (optional, default: false) */
+  showProgressBar?: boolean;
+  /** Custom style (optional, default: undefined) */
+  style?: CSSProperties;
+  /** Message present inside the drop zome (optional, default: 'Click or drag file to upload' ) */
+  uploadMessage?: string | ReactElement;
+}
+
+/**
+ * File field component
+ *
+ * File input wrapped in a generic field ( @see GenericField ).
+ *
+ * Calls @param onChange for every input change.
+ *
+ */
+export const FileField = (props: IFileFieldProps): ReactElement => {
+  const {
+    acceptTypes,
+    additionalInfo,
+    containerRef,
+    dataTestId,
+    disabled,
+    errorMessage,
+    fieldClassName,
+    fieldSize,
+    helperText,
+    highlighted,
+    inline,
+    inputClassName,
+    inputValue,
+    label,
+    labelSize,
+    mandatory,
+    maxFiles,
+    maxFileSize,
+    maxFolderDepth,
+    onChange,
+    onDelete,
+    onDownload,
+    readOnly,
+    requestHeaders,
+    requestMethod,
+    requestUrl,
+    requestWithCredentials,
+    showFileSize,
+    showProgressBar,
+    style,
+    uploadMessage,
+  } = props;
+
+  return (
+    <GenericField
+      containerRef={containerRef}
+      errorMessage={errorMessage}
+      fieldClassName={fieldClassName}
+      helperText={helperText}
+      highlighted={highlighted}
+      inline={inline}
+      invertInputDescription
+      label={label}
+      labelSize={labelSize}
+      mandatory={mandatory}
+      readOnly={readOnly}>
+      {additionalInfo}
+      <FileInput
+        acceptTypes={acceptTypes}
+        className={inputClassName}
+        dataTestId={dataTestId}
+        disabled={disabled}
+        fieldSize={fieldSize}
+        inputValue={inputValue}
+        isInError={errorMessage !== undefined}
+        maxFiles={maxFiles}
+        maxFileSize={maxFileSize}
+        maxFolderDepth={maxFolderDepth}
+        onChange={onChange}
+        onDelete={onDelete}
+        onDownload={onDownload}
+        readOnly={readOnly}
+        requestHeaders={requestHeaders}
+        requestMethod={requestMethod}
+        requestUrl={requestUrl}
+        requestWithCredentials={requestWithCredentials}
+        showFileSize={showFileSize}
+        showProgressBar={showProgressBar}
+        style={style}
+        uploadMessage={uploadMessage}
+      />
+    </GenericField>
+  );
+};
+
+FileField.defaultProps = {
+  acceptTypes: '*/*',
+  additionalInfo: undefined,
+  disabled: false,
+  errorMessage: undefined,
+  fieldClassName: undefined,
+  fieldSize: undefined,
+  helperText: undefined,
+  highlighted: false,
+  inline: false,
+  inputClassName: undefined,
+  inputValue: undefined,
+  label: undefined,
+  labelSize: undefined,
+  mandatory: false,
+  maxFiles: undefined,
+  maxFileSize: undefined,
+  maxFolderDepth: 2,
+  onDownload: undefined,
+  readOnly: false,
+  requestHeaders: undefined,
+  requestMethod: 'POST',
+  requestWithCredentials: undefined,
+  showFileSize: false,
+  showProgressBar: false,
+  style: undefined,
+  uploadMessage: 'Click or drag file to upload',
+};
+
+export default FileField;

--- a/src/Components/Molecules/FileField/index.ts
+++ b/src/Components/Molecules/FileField/index.ts
@@ -1,0 +1,1 @@
+export { default as FileField } from './FileField';

--- a/src/Components/Molecules/index.ts
+++ b/src/Components/Molecules/index.ts
@@ -4,6 +4,7 @@ export * from './CheckboxField';
 export * from './DatePickerField';
 export * from './DynamicSearchCreatableField';
 export * from './DynamicSearchField';
+export * from './FileField';
 export * from './MultiSelectField';
 export * from './PercentageField';
 export * from './Popover';

--- a/src/assets/_amount.scss
+++ b/src/assets/_amount.scss
@@ -6,8 +6,8 @@
   padding: 6px 8px;
   white-space: nowrap;
 
-  &:hover:not(:disabled):not(:read-only),
-  &:focus:not(:disabled):not(:read-only) {
+  &:hover:not(:disabled):not(:read-only):not(.amount-field-error),
+  &:focus:not(:disabled):not(:read-only):not(.amount-field-error) {
     border: 1px solid $primary;
   }
 

--- a/src/assets/_checkbox.scss
+++ b/src/assets/_checkbox.scss
@@ -39,6 +39,7 @@
 
     &.input-checkbox-field-read-only,
     &.input-checkbox-field-disabled {
+      cursor: default;
       color: $pebble;
 
       &:not(.input-checkbox-field-checked) {

--- a/src/assets/_switch.scss
+++ b/src/assets/_switch.scss
@@ -7,10 +7,16 @@
     position: relative;
     margin-bottom: 8px;
     width: fit-content;
+    cursor: pointer;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
+
+    &.input-switch-field-disabled,
+    &.input-switch-field-read-only {
+      cursor: default;
+    }
 
     .switch-marker {
       margin-right: 10px;


### PR DESCRIPTION
Fix: Atoms/AmountInput fix border color which was changing when in error and being hovered

Fix: Atoms/CheckboxInput fix cursor to default when in readonly of disabled
Fix: Atoms/SwitchInput fix cursor to be a point when input is editable, and default when in readonly or disabled
Fix: Atoms/DatePickerInput fix story using locale
Fix: Organisms/DatePickerField fix story using locale

Feat: Organisms/FileField component creation

Doc: Atoms/FileInput fix type