### PR TITLE
Fix: Fields reducing padding bottom to 4px

### DIFF
--- a/src/Components/Organisms/DataTable/Common/types.ts
+++ b/src/Components/Organisms/DataTable/Common/types.ts
@@ -121,6 +121,7 @@ export interface IColumnCode<T> extends IColumn {
 
 export interface IColumnCheckbox<T> extends IColumn {
   dataIndex: keyof T;
+  editable?: boolean;
   type: ColumnType.CHECKBOX;
 }
 

--- a/src/Components/Organisms/DataTable/EditableDataTable/EditableDataTable.stories.tsx
+++ b/src/Components/Organisms/DataTable/EditableDataTable/EditableDataTable.stories.tsx
@@ -109,7 +109,6 @@ const columns: IColumnType<IDemoType>[] = [
     sorter: true,
     type: ColumnType.AMOUNT,
     currency: '€',
-    editable: true,
   },
   {
     title: 'Percentage',

--- a/src/Components/Organisms/DataTable/EditableDataTable/EditableDataTableCell.tsx
+++ b/src/Components/Organisms/DataTable/EditableDataTable/EditableDataTableCell.tsx
@@ -40,7 +40,7 @@ const EditableDataTableCell = <T,>(props: IEditableDataTableCellProps<T>): React
           onChange={(newValue) => {
             handleUpdateDataChange(rowIndex, column.dataIndex, newValue);
           }}
-          editing={editable}
+          editing={column.editable && editable}
         />
       );
     }
@@ -55,7 +55,7 @@ const EditableDataTableCell = <T,>(props: IEditableDataTableCellProps<T>): React
           onChange={(newValue) => {
             handleUpdateDataChange(rowIndex, column.dataIndex, newValue);
           }}
-          editing={editable}
+          editing={column.editable && editable}
         />
       );
     }
@@ -92,6 +92,7 @@ const EditableDataTableCell = <T,>(props: IEditableDataTableCellProps<T>): React
           onChange={(newValue) => {
             handleUpdateDataChange(rowIndex, column.dataIndex, newValue);
           }}
+          editing={column.editable && editable}
         />
       );
     }
@@ -106,7 +107,7 @@ const EditableDataTableCell = <T,>(props: IEditableDataTableCellProps<T>): React
           onChange={(newValue) => {
             handleUpdateDataChange(rowIndex, column.dataIndex, newValue);
           }}
-          editing={editable}
+          editing={column.editable && editable}
         />
       );
     }
@@ -121,7 +122,7 @@ const EditableDataTableCell = <T,>(props: IEditableDataTableCellProps<T>): React
           onChange={(newValue) => {
             handleUpdateDataChange(rowIndex, column.dataIndex, newValue);
           }}
-          editing={editable}
+          editing={column.editable && editable}
         />
       );
     }
@@ -136,6 +137,7 @@ const EditableDataTableCell = <T,>(props: IEditableDataTableCellProps<T>): React
           onChange={(newValue) => {
             handleUpdateDataChange(rowIndex, column.dataIndex, newValue);
           }}
+          editing={column.editable && editable}
         />
       );
     }
@@ -150,7 +152,7 @@ const EditableDataTableCell = <T,>(props: IEditableDataTableCellProps<T>): React
           onChange={(newValue) => {
             handleUpdateDataChange(rowIndex, column.dataIndex, newValue);
           }}
-          editing={editable}
+          editing={column.editable && editable}
         />
       );
     }
@@ -165,7 +167,7 @@ const EditableDataTableCell = <T,>(props: IEditableDataTableCellProps<T>): React
           onChange={(newValue) => {
             handleUpdateDataChange(rowIndex, column.dataIndex, newValue);
           }}
-          editing={editable}
+          editing={column.editable && editable}
         />
       );
     }
@@ -180,7 +182,7 @@ const EditableDataTableCell = <T,>(props: IEditableDataTableCellProps<T>): React
           onChange={(newValue) => {
             handleUpdateDataChange(rowIndex, column.dataIndex, newValue);
           }}
-          editing={editable}
+          editing={column.editable && editable}
         />
       );
     }

--- a/src/assets/_field.scss
+++ b/src/assets/_field.scss
@@ -23,7 +23,7 @@
   .field-label {
     display: flex;
     font-weight: 600;
-    padding-bottom: 8px;
+    padding-bottom: 4px;
     align-items: center;
 
     .field-label-mandatory {


### PR DESCRIPTION
Fix: Fields reducing padding bottom to 4px
Fix: Organisms/CheckboxCell provide the ability to disable edition on that column
Fx: Organisms/EditableDataTable ensure column and row are editable (and not only row)