### PR TITLE
Fix: Atoms/modal removing the zindex of the modal

### DIFF
--- a/src/Components/Atoms/SelectInput/DynamicSearchCreatableInput.tsx
+++ b/src/Components/Atoms/SelectInput/DynamicSearchCreatableInput.tsx
@@ -225,6 +225,7 @@ const DynamicSearchCreatableInput = (props: IDynamicSearchCreatableInputProps): 
         maxMenuHeight={maxMenuHeight}
         menuPlacement='auto'
         menuPortalTarget={usePortal ? document.querySelector('body') : undefined}
+        menuShouldBlockScroll={true}
         noOptionsMessage={localNoOptionMessage}
         onChange={(option) => {
           if (onChange) {

--- a/src/Components/Atoms/SelectInput/DynamicSearchInput.tsx
+++ b/src/Components/Atoms/SelectInput/DynamicSearchInput.tsx
@@ -204,6 +204,7 @@ const DynamicSearchInput = (props: IDynamicSearchInputProps): ReactElement => {
         maxMenuHeight={maxMenuHeight}
         menuPlacement='auto'
         menuPortalTarget={usePortal ? document.querySelector('body') : undefined}
+        menuShouldBlockScroll={true}
         noOptionsMessage={localNoOptionMessage}
         onChange={(option) => {
           if (onChange) {

--- a/src/Components/Atoms/SelectInput/MultiSelectInput.tsx
+++ b/src/Components/Atoms/SelectInput/MultiSelectInput.tsx
@@ -201,6 +201,7 @@ const MultiSelectInput = (props: IMultiSelectInputProps): ReactElement => {
         maxMenuHeight={maxMenuHeight}
         menuPlacement='auto'
         menuPortalTarget={usePortal ? document.querySelector('body') : undefined}
+        menuShouldBlockScroll={true}
         onChange={(options) => {
           if (onChange) {
             onChange(options.map((option) => option.value));

--- a/src/Components/Atoms/SelectInput/SelectInput.tsx
+++ b/src/Components/Atoms/SelectInput/SelectInput.tsx
@@ -135,6 +135,7 @@ const SelectInput = (props: ISelectInputProps): ReactElement => {
         isSearchable
         maxMenuHeight={maxMenuHeight}
         menuPlacement='auto'
+        menuShouldBlockScroll={true}
         name={name}
         onChange={(option) => {
           if (onChange) {

--- a/src/Components/Atoms/SelectInput/__test__/__snapshots__/DynamicSearchCreatableInput.test.tsx.snap
+++ b/src/Components/Atoms/SelectInput/__test__/__snapshots__/DynamicSearchCreatableInput.test.tsx.snap
@@ -83,6 +83,9 @@ exports[`DynamicSearchCreatableInput Component DynamicSearchCreatableInput handl
             id="react-select-6-listbox"
           >
             <div
+              class="css-bp8cua-ScrollManager"
+            />
+            <div
               class=" css-4ljt47-MenuList"
             >
               <div
@@ -287,6 +290,9 @@ exports[`DynamicSearchCreatableInput Component DynamicSearchCreatableInput handl
             class=" css-26l3qy-menu"
             id="react-select-11-listbox"
           >
+            <div
+              class="css-bp8cua-ScrollManager"
+            />
             <div
               class=" css-4ljt47-MenuList"
             >

--- a/src/Components/Atoms/SelectInput/__test__/__snapshots__/DynamicSearchInput.test.tsx.snap
+++ b/src/Components/Atoms/SelectInput/__test__/__snapshots__/DynamicSearchInput.test.tsx.snap
@@ -83,6 +83,9 @@ exports[`DynamicSearchInput Component DynamicSearchInput handles change 1`] = `
             id="react-select-6-listbox"
           >
             <div
+              class="css-bp8cua-ScrollManager"
+            />
+            <div
               class=" css-4ljt47-MenuList"
             >
               <div
@@ -287,6 +290,9 @@ exports[`DynamicSearchInput Component DynamicSearchInput handles change to undef
             class=" css-26l3qy-menu"
             id="react-select-11-listbox"
           >
+            <div
+              class="css-bp8cua-ScrollManager"
+            />
             <div
               class=" css-4ljt47-MenuList"
             >

--- a/src/Components/Organisms/DataTable/Common/Cells/BadgeCell.tsx
+++ b/src/Components/Organisms/DataTable/Common/Cells/BadgeCell.tsx
@@ -43,6 +43,7 @@ const BadgeCell = <T,>(props: ICellProps<T, IColumnBadge<T>>): ReactElement => {
             }
           }}
           options={options}
+          usePortal={column.usePortal}
         />
       ) : (
         <Badge className='table--cell--value--badge-no-margin' color={column.color}>

--- a/src/Components/Organisms/DataTable/Common/Cells/__test__/__snapshots__/DynamicSearchCell.test.tsx.snap
+++ b/src/Components/Organisms/DataTable/Common/Cells/__test__/__snapshots__/DynamicSearchCell.test.tsx.snap
@@ -228,6 +228,9 @@ exports[`DynamicSearchCell component DynamicSearchCell renders in edit mode and 
                       id="react-select-2-listbox"
                     >
                       <div
+                        class="css-bp8cua-ScrollManager"
+                      />
+                      <div
                         class=" css-4ljt47-MenuList"
                       >
                         <div

--- a/src/Components/Organisms/DataTable/Common/types.ts
+++ b/src/Components/Organisms/DataTable/Common/types.ts
@@ -106,6 +106,7 @@ export interface IColumnBadge<T> extends IColumn {
   };
   placeholder?: string;
   type: ColumnType.BADGE;
+  usePortal?: boolean;
 }
 
 export interface IColumnButton<T> extends IColumn {
@@ -146,6 +147,7 @@ export interface IColumnDate<T> extends IColumn {
   isClearable?: boolean;
   locale?: string;
   type: ColumnType.DATE;
+  usePortal?: boolean;
 }
 
 export interface IColumnDynamicSearch<T> extends IColumn {

--- a/src/Components/Organisms/DataTable/LineEditableDataTable/LineEditableDataTable.advanced.stories.tsx
+++ b/src/Components/Organisms/DataTable/LineEditableDataTable/LineEditableDataTable.advanced.stories.tsx
@@ -34,6 +34,16 @@ const teams: Array<ITeam> = [
     name: 'Product',
     description: 'Making the possible impossible',
   },
+  {
+    teamId: 4,
+    name: 'Architect',
+    description: 'Making the impossible strong',
+  },
+  {
+    teamId: 5,
+    name: 'Designer',
+    description: 'Making the impossible look nice',
+  },
 ];
 
 enum LinkedObjectType {
@@ -134,6 +144,13 @@ const columns: Array<IColumnType<ITaskView>> = [
       ]),
   },
   {
+    dataIndex: 'comment',
+    editable: true,
+    title: 'Comment',
+    type: ColumnType.TEXTAREA,
+    hidden: true,
+  },
+  {
     dataIndex: 'team',
     editable: true,
     ellipsis: true,
@@ -144,13 +161,6 @@ const columns: Array<IColumnType<ITaskView>> = [
       label: team.name,
       value: team.teamId,
     })),
-  },
-  {
-    dataIndex: 'comment',
-    editable: true,
-    title: 'Comment',
-    type: ColumnType.TEXTAREA,
-    hidden: true,
   },
 ];
 

--- a/src/Components/Organisms/DataTable/LineEditableDataTable/LineEditableModal.tsx
+++ b/src/Components/Organisms/DataTable/LineEditableDataTable/LineEditableModal.tsx
@@ -54,6 +54,7 @@ const columnToFieldMapper = <T,>(columns: Array<IColumnType<T>>): Array<IFieldAn
             options: column.options,
             placeholder: column.placeholder,
             readOnly: !column.editable,
+            usePortal: column.usePortal,
           };
         }
         case ColumnType.BUTTON: {
@@ -79,6 +80,7 @@ const columnToFieldMapper = <T,>(columns: Array<IColumnType<T>>): Array<IFieldAn
             label: column.title,
             locale: column.locale,
             readOnly: !column.editable,
+            usePortal: column.usePortal,
           };
         }
         // TODO add description mapping
@@ -169,7 +171,6 @@ const LineEditableModal = <T,>(props: ILineEditableModalProps<T>): ReactElement 
     initialData: row,
     previousData: showChanges ? cloneDeep(row) : undefined,
     fields: columnToFieldMapper(columns),
-    usePortal: false,
     validationSchema: extra?.validationSchema,
   });
 

--- a/src/assets/_modal.scss
+++ b/src/assets/_modal.scss
@@ -6,7 +6,6 @@
   left: 0;
   background-color: rgba(0, 0, 0, 0.7);
   overflow-x: scroll;
-  z-index: 100;
 
   .modal-content {
     position: relative;


### PR DESCRIPTION
Fix: Atoms/modal removing the zindex of the modal
Fix: Atoms/DynamicSearchCreatableInput prevent scroll with the dropdown open
Fix: Atoms/DynamicSearchInput prevent scroll with the dropdown open
Fix: Atoms/MultiselectInput prevent scroll with the dropdown open
Fix: Atoms/SelectInput prevent scroll with the dropdown open
Fix: Organisms/LineEditableDataTable use portal in the modal for select