### PR TITLE
prepare build 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.4.1 (2022-04-13)
+
+### Bug Fixes
+
+Atoms/DatePickerInput stop propagation onClickoutside
+Atoms/DynamicSearchCreatableInput supporting controlled method (reset from the input, set from the input, ...)
+Atoms/DynamicSearchInput supporting controlled method (reset from the input, set from the input, ...)
+Atoms/YearPickerInput stop propagation onClickoutside
+Molecules/Field add overflow hidden for filter
+Organisms/Filter set search field of the bar flex grow 1 and flex shrink 1
+Organisms/FilterItem enable portal for date picker
+hooks/useOnClickOutside now check if the dom target is in the ref and if the x y coordinates are inside the area of the object
+
 ## 1.4.0 (2022-04-12)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghost-design-system",
-  "version": "1.4.1-next-0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ghost-design-system",
-      "version": "1.4.1-next-0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghost-design-system",
-  "version": "1.4.0",
+  "version": "1.4.1-next-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ghost-design-system",
-      "version": "1.4.0",
+      "version": "1.4.1-next-0",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghost-design-system",
   "license": "MIT",
-  "version": "1.4.0",
+  "version": "1.4.1-next-0",
   "description": "Ghost design system - React Component Library",
   "author": {
     "name": "Charles Coqueret",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghost-design-system",
   "license": "MIT",
-  "version": "1.4.1-next-0",
+  "version": "1.4.1",
   "description": "Ghost design system - React Component Library",
   "author": {
     "name": "Charles Coqueret",

--- a/src/Components/Atoms/DatePickerInput/DatePickerInput.tsx
+++ b/src/Components/Atoms/DatePickerInput/DatePickerInput.tsx
@@ -91,6 +91,9 @@ const DatePickerInput = (props: IDatePickerProps): ReactElement => {
         popperContainer={usePortal ? Portal : undefined}
         renderCustomHeader={DatePickerHeader(locale)}
         autoComplete='off'
+        onClickOutside={(event) => {
+          event.stopPropagation();
+        }}
       />
     </div>
   );

--- a/src/Components/Atoms/DatePickerInput/YearPickerInput.tsx
+++ b/src/Components/Atoms/DatePickerInput/YearPickerInput.tsx
@@ -85,6 +85,9 @@ const YearPickerInput = (props: IYearPickerProps): ReactElement => {
         autoComplete='off'
         popperContainer={usePortal ? Portal : undefined}
         showYearPicker
+        onClickOutside={(event) => {
+          event.stopPropagation();
+        }}
       />
     </div>
   );

--- a/src/Components/Atoms/SelectInput/DynamicSearchCreatableInput.tsx
+++ b/src/Components/Atoms/SelectInput/DynamicSearchCreatableInput.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { default as ReactSelectAsyncCreatable } from 'react-select/async-creatable';
 import { ClearIndicatorProps, DropdownIndicatorProps, LoadingIndicatorProps } from 'react-select';
 import classnames from 'classnames';
@@ -82,17 +82,14 @@ const DynamicSearchCreatableInput = (props: IDynamicSearchCreatableInputProps): 
   const [isCreating, setIsCreating] = useState(false);
   const [currentOption, setCurrentOption] = useState<IOption>();
 
-  const localNoOptionMessage = useCallback(
-    (inputObject: { inputValue: string }): string => {
-      if (typeof noOptionsMessage === 'string') {
-        return noOptionsMessage;
-      }
-      return noOptionsMessage(inputObject);
-    },
-    [noOptionsMessage],
-  );
+  const localNoOptionMessage = (inputObject: { inputValue: string }): string => {
+    if (typeof noOptionsMessage === 'string') {
+      return noOptionsMessage;
+    }
+    return noOptionsMessage(inputObject);
+  };
 
-  const resolveIncomingValue = useCallback(() => {
+  const resolveIncomingValue = () => {
     if (inputValue && inputValue !== currentOption?.value) {
       setIsLoading(true);
       resolveValue(inputValue)
@@ -106,10 +103,9 @@ const DynamicSearchCreatableInput = (props: IDynamicSearchCreatableInputProps): 
           setIsLoading(false);
         });
     } else {
-      setIsLoading(false);
       setCurrentOption(undefined);
     }
-  }, [inputValue, resolveValue]);
+  };
 
   const localHandleCreate = (newLabel: string) => {
     setIsLoading(true);
@@ -128,10 +124,8 @@ const DynamicSearchCreatableInput = (props: IDynamicSearchCreatableInputProps): 
   };
 
   useEffect(() => {
-    setIsLoading(true);
-    setCurrentOption(undefined);
-    resolveIncomingValue();
-  }, [inputValue, resolveIncomingValue]);
+    if (inputValue !== currentOption?.value) resolveIncomingValue();
+  }, [inputValue]);
 
   if (readOnly) {
     return (

--- a/src/Components/Atoms/SelectInput/DynamicSearchInput.tsx
+++ b/src/Components/Atoms/SelectInput/DynamicSearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { default as ReactSelectAsync } from 'react-select/async';
 import { ClearIndicatorProps, DropdownIndicatorProps, LoadingIndicatorProps } from 'react-select';
 import classnames from 'classnames';
@@ -78,17 +78,14 @@ const DynamicSearchInput = (props: IDynamicSearchInputProps): ReactElement => {
   const [isLoading, setIsLoading] = useState(false);
   const [currentOption, setCurrentOption] = useState<IOption>();
 
-  const localNoOptionMessage = useCallback(
-    (inputObject: { inputValue: string }): string => {
-      if (typeof noOptionsMessage === 'string') {
-        return noOptionsMessage;
-      }
-      return noOptionsMessage(inputObject);
-    },
-    [noOptionsMessage],
-  );
+  const localNoOptionMessage = (inputObject: { inputValue: string }): string => {
+    if (typeof noOptionsMessage === 'string') {
+      return noOptionsMessage;
+    }
+    return noOptionsMessage(inputObject);
+  };
 
-  const resolveIncomingValue = useCallback(() => {
+  const resolveIncomingValue = () => {
     if (inputValue && inputValue !== currentOption?.value) {
       setIsLoading(true);
       resolveValue(inputValue)
@@ -101,17 +98,14 @@ const DynamicSearchInput = (props: IDynamicSearchInputProps): ReactElement => {
         .finally(() => {
           setIsLoading(false);
         });
-    } else {
-      setIsLoading(false);
+    } else if (currentOption) {
       setCurrentOption(undefined);
     }
-  }, [inputValue, resolveValue]);
+  };
 
   useEffect(() => {
-    setIsLoading(true);
-    setCurrentOption(undefined);
-    resolveIncomingValue();
-  }, [inputValue, resolveIncomingValue]);
+    if (inputValue !== currentOption?.value) resolveIncomingValue();
+  }, [inputValue]);
 
   if (readOnly) {
     return (
@@ -149,6 +143,7 @@ const DynamicSearchInput = (props: IDynamicSearchInputProps): ReactElement => {
         className,
       )}>
       <ReactSelectAsync<IOption, false>
+        backspaceRemovesValue={isClearable}
         closeMenuOnSelect={true}
         components={{
           LoadingIndicator: (props: LoadingIndicatorProps<IOption, false>) => {
@@ -190,6 +185,7 @@ const DynamicSearchInput = (props: IDynamicSearchInputProps): ReactElement => {
         }}
         data-testid={dataTestId}
         defaultOptions
+        defaultValue={null}
         hideSelectedOptions={false}
         inputId={dataTestId}
         isClearable={isClearable}
@@ -208,11 +204,12 @@ const DynamicSearchInput = (props: IDynamicSearchInputProps): ReactElement => {
             onChange(option?.value);
           }
           setCurrentOption(option || undefined);
+
           setIsLoading(false);
         }}
         placeholder={placeholder}
         styles={customStyles({ ...colors, isInError })}
-        value={currentOption}
+        value={currentOption === undefined ? null : currentOption}
       />
     </div>
   );

--- a/src/Components/Organisms/Filter/FilterItem.tsx
+++ b/src/Components/Organisms/Filter/FilterItem.tsx
@@ -59,7 +59,6 @@ const FilterItem = <T,>(props: IFilterItemProps<T>): ReactElement => {
             onChange(item.dataIndex, newValue as unknown as T[keyof T]);
           }}
           inline={inline}
-          usePortal={inline}
         />
       );
     }

--- a/src/Components/Organisms/Filter/__test__/Filter.test.tsx
+++ b/src/Components/Organisms/Filter/__test__/Filter.test.tsx
@@ -134,10 +134,14 @@ describe('Filter Component', () => {
     });
     expect(onChangeMock).toBeCalledTimes(1);
 
+    expect(baseElement).toMatchSnapshot();
+
     // Resetting the value in the modal
     const resetAdvanceSearchButton = await screen.findByTestId('DATA-TEST-ID-advanced-reset');
     userEvent.click(resetAdvanceSearchButton);
     expect(onChangeMock).toBeCalledTimes(1);
+
+    expect(baseElement).toMatchSnapshot();
 
     // Submitting the value and closing the modal
     act(() => {
@@ -145,6 +149,8 @@ describe('Filter Component', () => {
         onChangeHandlerFilterItemAdvancedSearch('number', 100);
       }
     });
+
+    expect(baseElement).toMatchSnapshot();
 
     const submitAdvanceSearchButton = await screen.findByTestId('DATA-TEST-ID-advanced-submit');
     userEvent.click(submitAdvanceSearchButton);

--- a/src/Components/Organisms/Filter/__test__/__snapshots__/Filter.test.tsx.snap
+++ b/src/Components/Organisms/Filter/__test__/__snapshots__/Filter.test.tsx.snap
@@ -182,6 +182,393 @@ exports[`Filter Component Filter renders advanced filter and handles changes 2`]
 
 exports[`Filter Component Filter renders advanced filter and handles changes 3`] = `
 <body
+  style="overflow-y: hidden; overflow-x: hidden;"
+>
+  <div>
+    <div
+      class="filter-container"
+    >
+      <div
+        class="searchbar"
+      >
+        <div
+          class="search-field"
+        >
+          <div>
+            Mocked FilterItem props: 
+            {"inputValues":{"number":1},"item":{"dataIndex":"number","filterType":"number","label":"Number","placeholder":"Search number"},"inline":true}
+          </div>
+        </div>
+        <div
+          class="search-actions"
+        >
+          <button
+            class="gds-button-content"
+            color="secondary"
+            data-testid="DATA-TEST-ID-reset"
+            type="button"
+          >
+            <div
+              class="button-label-container"
+            >
+              reset
+            </div>
+          </button>
+          <button
+            class="gds-button-content"
+            color="primary"
+            data-testid="DATA-TEST-ID-open-advanced"
+            type="button"
+          >
+            <div
+              class="button-label-container"
+            >
+              advancedSearch
+            </div>
+          </button>
+        </div>
+      </div>
+      <div>
+        <div
+          class="gds-modal-overlay"
+        >
+          <div
+            class="modal-content size-lg"
+          >
+            <div
+              class="modal-header"
+            >
+              <div
+                class="modal-title"
+              >
+                advancedSearchTitle
+              </div>
+              <div
+                class="modal-close-icon"
+              >
+                <i
+                  class="icon"
+                  icon="fal,times"
+                />
+              </div>
+            </div>
+            <div
+              class="modal-body"
+            >
+              <div
+                class="gds-layout-container"
+              >
+                <div
+                  class="gds-layout-row"
+                >
+                  <div>
+                    Mocked FilterItem props: 
+                    {"inputValues":{"number":10},"item":{"dataIndex":"number","filterType":"number","label":"Number","placeholder":"Search number","dataTestId":"NUMBER-ADVANCED-SEARCH"}}
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="modal-footer"
+            >
+              <button
+                class="gds-button-content"
+                color="secondary"
+                data-testid="DATA-TEST-ID-advanced-reset"
+                type="button"
+              >
+                <div
+                  class="button-label-container"
+                >
+                  reset
+                </div>
+              </button>
+              <button
+                class="gds-button-content"
+                color="primary"
+                data-testid="DATA-TEST-ID-advanced-submit"
+                type="button"
+              >
+                <div
+                  class="button-label-container"
+                >
+                  search
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    id="root-portal-id"
+  >
+    <div />
+  </div>
+</body>
+`;
+
+exports[`Filter Component Filter renders advanced filter and handles changes 4`] = `
+<body
+  style="overflow-y: hidden; overflow-x: hidden;"
+>
+  <div>
+    <div
+      class="filter-container"
+    >
+      <div
+        class="searchbar"
+      >
+        <div
+          class="search-field"
+        >
+          <div>
+            Mocked FilterItem props: 
+            {"inputValues":{"number":1},"item":{"dataIndex":"number","filterType":"number","label":"Number","placeholder":"Search number"},"inline":true}
+          </div>
+        </div>
+        <div
+          class="search-actions"
+        >
+          <button
+            class="gds-button-content"
+            color="secondary"
+            data-testid="DATA-TEST-ID-reset"
+            type="button"
+          >
+            <div
+              class="button-label-container"
+            >
+              reset
+            </div>
+          </button>
+          <button
+            class="gds-button-content"
+            color="primary"
+            data-testid="DATA-TEST-ID-open-advanced"
+            type="button"
+          >
+            <div
+              class="button-label-container"
+            >
+              advancedSearch
+            </div>
+          </button>
+        </div>
+      </div>
+      <div>
+        <div
+          class="gds-modal-overlay"
+        >
+          <div
+            class="modal-content size-lg"
+          >
+            <div
+              class="modal-header"
+            >
+              <div
+                class="modal-title"
+              >
+                advancedSearchTitle
+              </div>
+              <div
+                class="modal-close-icon"
+              >
+                <i
+                  class="icon"
+                  icon="fal,times"
+                />
+              </div>
+            </div>
+            <div
+              class="modal-body"
+            >
+              <div
+                class="gds-layout-container"
+              >
+                <div
+                  class="gds-layout-row"
+                >
+                  <div>
+                    Mocked FilterItem props: 
+                    {"inputValues":{"number":1},"item":{"dataIndex":"number","filterType":"number","label":"Number","placeholder":"Search number","dataTestId":"NUMBER-ADVANCED-SEARCH"}}
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="modal-footer"
+            >
+              <button
+                class="gds-button-content"
+                color="secondary"
+                data-testid="DATA-TEST-ID-advanced-reset"
+                type="button"
+              >
+                <div
+                  class="button-label-container"
+                >
+                  reset
+                </div>
+              </button>
+              <button
+                class="gds-button-content"
+                color="primary"
+                data-testid="DATA-TEST-ID-advanced-submit"
+                type="button"
+              >
+                <div
+                  class="button-label-container"
+                >
+                  search
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    id="root-portal-id"
+  >
+    <div />
+  </div>
+</body>
+`;
+
+exports[`Filter Component Filter renders advanced filter and handles changes 5`] = `
+<body
+  style="overflow-y: hidden; overflow-x: hidden;"
+>
+  <div>
+    <div
+      class="filter-container"
+    >
+      <div
+        class="searchbar"
+      >
+        <div
+          class="search-field"
+        >
+          <div>
+            Mocked FilterItem props: 
+            {"inputValues":{"number":1},"item":{"dataIndex":"number","filterType":"number","label":"Number","placeholder":"Search number"},"inline":true}
+          </div>
+        </div>
+        <div
+          class="search-actions"
+        >
+          <button
+            class="gds-button-content"
+            color="secondary"
+            data-testid="DATA-TEST-ID-reset"
+            type="button"
+          >
+            <div
+              class="button-label-container"
+            >
+              reset
+            </div>
+          </button>
+          <button
+            class="gds-button-content"
+            color="primary"
+            data-testid="DATA-TEST-ID-open-advanced"
+            type="button"
+          >
+            <div
+              class="button-label-container"
+            >
+              advancedSearch
+            </div>
+          </button>
+        </div>
+      </div>
+      <div>
+        <div
+          class="gds-modal-overlay"
+        >
+          <div
+            class="modal-content size-lg"
+          >
+            <div
+              class="modal-header"
+            >
+              <div
+                class="modal-title"
+              >
+                advancedSearchTitle
+              </div>
+              <div
+                class="modal-close-icon"
+              >
+                <i
+                  class="icon"
+                  icon="fal,times"
+                />
+              </div>
+            </div>
+            <div
+              class="modal-body"
+            >
+              <div
+                class="gds-layout-container"
+              >
+                <div
+                  class="gds-layout-row"
+                >
+                  <div>
+                    Mocked FilterItem props: 
+                    {"inputValues":{"number":100},"item":{"dataIndex":"number","filterType":"number","label":"Number","placeholder":"Search number","dataTestId":"NUMBER-ADVANCED-SEARCH"}}
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="modal-footer"
+            >
+              <button
+                class="gds-button-content"
+                color="secondary"
+                data-testid="DATA-TEST-ID-advanced-reset"
+                type="button"
+              >
+                <div
+                  class="button-label-container"
+                >
+                  reset
+                </div>
+              </button>
+              <button
+                class="gds-button-content"
+                color="primary"
+                data-testid="DATA-TEST-ID-advanced-submit"
+                type="button"
+              >
+                <div
+                  class="button-label-container"
+                >
+                  search
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    id="root-portal-id"
+  >
+    <div />
+  </div>
+</body>
+`;
+
+exports[`Filter Component Filter renders advanced filter and handles changes 6`] = `
+<body
   style=""
 >
   <div>

--- a/src/Components/Organisms/Filter/__test__/__snapshots__/FilterItem.test.tsx.snap
+++ b/src/Components/Organisms/Filter/__test__/__snapshots__/FilterItem.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`FilterItem Component FilterItem renders DatePickerField 1`] = `
 <div>
   <div>
     Mocked DatePickerField props: 
-    {"name":"date","inputValue":"2022-04-10T00:00:00.000Z","inline":false,"usePortal":false}
+    {"name":"date","inputValue":"2022-04-10T00:00:00.000Z","inline":false}
   </div>
 </div>
 `;

--- a/src/assets/_field.scss
+++ b/src/assets/_field.scss
@@ -72,6 +72,7 @@
 
 .field {
   display: flex;
+  overflow: hidden;
 }
 
 @for $size from 1 through 12 {

--- a/src/assets/_filter.scss
+++ b/src/assets/_filter.scss
@@ -8,7 +8,7 @@
       display: flex;
       flex-direction: row;
       gap: 8px;
-      flex-grow: 1;
+      flex: 1 1;
     }
 
     .search-actions {

--- a/src/hooks/use-on-click-outside.ts
+++ b/src/hooks/use-on-click-outside.ts
@@ -6,16 +6,32 @@ type Handler = (event: Event) => void;
 /** Hook capturing the click outside of a reference element and triggering the callback function */
 const useOnClickOutside = <T extends HTMLElement = HTMLElement>(ref: RefObject<T>, handler: Handler): void => {
   useEventListener('mousedown', (event) => {
+    if (!ref.current || !(event instanceof MouseEvent)) return;
+
+    const x = 'x' in event ? event.x : undefined;
+    const y = 'y' in event ? event.y : undefined;
+    const bound = ref.current.getBoundingClientRect();
+
     const el = ref?.current;
-    if (!el || el.contains(event.target as Node)) {
+    if (
+      !el ||
+      el.contains(event.target as Node) ||
+      (x && y && x > bound.left && x < bound.right && y > bound.top && y < bound.bottom)
+    ) {
       return;
     }
+
     handler(event);
   });
 
   useEventListener('touchstart', (event) => {
-    const el = ref?.current;
-    if (!el || el.contains(event.target as Node)) {
+    if (!ref.current || !(event instanceof TouchEvent)) return;
+
+    const x = 'touches' in event ? event.touches[0].clientX : undefined;
+    const y = 'touches' in event ? event.touches[0].clientY : undefined;
+    const bound = ref.current.getBoundingClientRect();
+
+    if (x && y && x > bound.left && x < bound.right && y > bound.top && y < bound.bottom) {
       return;
     }
     handler(event);


### PR DESCRIPTION
Atoms/DatePickerInput stop propagation onClickoutside
Atoms/DynamicSearchCreatableInput supporting controlled method (reset from the input, set from the input, ...)
Atoms/DynamicSearchInput supporting controlled method (reset from the input, set from the input, ...)
Atoms/YearPickerInput stop propagation onClickoutside
Molecules/Field add overflow hidden for filter
Organisms/Filter set search field of the bar flex grow 1 and flex shrink 1
Organisms/FilterItem enable portal for date picker
hooks/useOnClickOutside now check if the dom target is in the ref and if the x y coordinates are inside the area of the object