### PR TITLE
Next

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
   "arrowParens": "always",
   "bracketSameLine": true,
+  "endOfLine": "auto",
   "jsxSingleQuote": true,
   "printWidth": 120,
   "semi": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.7 (2022-05-20)
+
+- Organisms/SideBar scss should only transition left and visibility instead of all
+- Organisms/SideBar use stretch instead of fill-available scss
+- Organisms/Datatable ensure the gutter column is displayed when total or select are displayed
+
 ## 1.4.6 (2022-05-08)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -42,18 +42,20 @@
   - [Text field](https://charlescoqueret.github.io/ghost-design-system/?path=/story/molecule-textfield--default)
   - [YearPicker field](https://charlescoqueret.github.io/ghost-design-system/?path=/story/molecule-yearpickerfield--default)
 - Organisms:
-  - [ActionBar](https://charlescoqueret.github.io/ghost-design-system/?path=/story/organism-actionbar--default)
+  - [ActionBar](https://charlescoqueret.github.io/ghost-design-system/?path=/docs/organism--action-bar)
   - Datatable:
-    - [Editable Data Table (full editable)](https://charlescoqueret.github.io/ghost-design-system/?path=/story/organism-datatable-editabledatatable--default)
-    - [Line editable Data Table (editon in popup form with data validation)](https://charlescoqueret.github.io/ghost-design-system/?path=/story/organism-datatable-lineeditabledatatable--default)
-    - [Line editable in place data table (edition of a line in place)](https://charlescoqueret.github.io/ghost-design-system/?path=/story/organism-datatable-lineeditableinplacedatatable--default)
-    - [Static data table](https://charlescoqueret.github.io/ghost-design-system/?path=/story/organism-datatable-staticdatatable--default)
-  - [Filter](https://charlescoqueret.github.io/ghost-design-system/?path=/story/organism-filter--default)
+    - [Generic Data Table](https://charlescoqueret.github.io/ghost-design-system/?path=/docs/organism-datatable--data-table)
+    - [Editable Data Table (full editable)](https://charlescoqueret.github.io/ghost-design-system/?path=/docs/organism-datatable--editable-data-table)
+    - [Line editable Data Table (editon in popup form with data validation)](https://charlescoqueret.github.io/ghost-design-system/?path=/docs/organism-datatable--line-editable-data-table)
+    - [Line editable in place data table (edition of a line in place)](https://charlescoqueret.github.io/ghost-design-system/?path=/docs/organism-datatable--line-editable-in-place-data-table)
+    - [Static data table](https://charlescoqueret.github.io/ghost-design-system/?path=/docs/organism-datatable--static-data-table)
+    - [Colunns](https://charlescoqueret.github.io/ghost-design-system/?path=/docs/organism-datatable-columns--page)
+  - [Filter](https://charlescoqueret.github.io/ghost-design-system/?path=/docs/organism--filter)
   - Form:
     - Form component
     - [useForm hook](https://charlescoqueret.github.io/ghost-design-system/?path=/story/organism-useform--default)
-  - [NavBar](https://charlescoqueret.github.io/ghost-design-system/?path=/story/organism-navbar--default)
-  - [SideBar](https://charlescoqueret.github.io/ghost-design-system/?path=/story/organism-sidebar--default)
+  - [NavBar](https://charlescoqueret.github.io/ghost-design-system/?path=/docs/organism--nav-bar)
+  - [SideBar](https://charlescoqueret.github.io/ghost-design-system/?path=/docs/organism--side-bar)
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghost-design-system",
-  "version": "1.4.7-next.0",
+  "version": "1.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ghost-design-system",
-      "version": "1.4.7-next.0",
+      "version": "1.4.7",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghost-design-system",
-  "version": "1.4.6",
+  "version": "1.4.7-next.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ghost-design-system",
-      "version": "1.4.6",
+      "version": "1.4.7-next.0",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghost-design-system",
   "license": "MIT",
-  "version": "1.4.7-next.0",
+  "version": "1.4.7",
   "description": "Ghost design system - React Component Library",
   "author": {
     "name": "Charles Coqueret",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghost-design-system",
   "license": "MIT",
-  "version": "1.4.6",
+  "version": "1.4.7-next.0",
   "description": "Ghost design system - React Component Library",
   "author": {
     "name": "Charles Coqueret",

--- a/src/Components/Organisms/DataTable/EditableDataTable/EditableDataTableBody.tsx
+++ b/src/Components/Organisms/DataTable/EditableDataTable/EditableDataTableBody.tsx
@@ -21,6 +21,7 @@ const EditableDataTableBody = <T,>(props: IEditableDataTableBodyProps<T>): React
   const [selectedRows, setSelectedRows] = useState<Record<number, boolean>>({});
 
   const isSelectable = extra.onRowSelect;
+  const isExtended = extra.onRowSelect || extra.computeTotal;
 
   const handleRowClick = (row: T, rowIndex: number) => {
     return extra && extra.onRowClick
@@ -63,15 +64,17 @@ const EditableDataTableBody = <T,>(props: IEditableDataTableBodyProps<T>): React
             onKeyUp={handleRowClick(row, rowIndex)}
             className={classnames({ pointer: extra && extra.onRowClick, selected: selectedRows[rowIndex] })}
             tabIndex={extra && extra.onRowClick ? 0 : -1}>
-            {isSelectable && (
-              <DataTableCellSelectable
-                handleSelectClick={handleSelectClick(row, rowIndex)}
-                selected={selectedRows[rowIndex]}
-                selectable={extra.isSelectable ? extra.isSelectable(row, rowIndex) : true}
-                dataTestId={`select-row-${rowIndex}`}
-              />
-            )}
-
+            {isExtended &&
+              (isSelectable ? (
+                <DataTableCellSelectable
+                  handleSelectClick={handleSelectClick(row, rowIndex)}
+                  selected={selectedRows[rowIndex]}
+                  selectable={extra.isSelectable ? extra.isSelectable(row, rowIndex) : true}
+                  dataTestId={`select-row-${rowIndex}`}
+                />
+              ) : (
+                <td></td>
+              ))}
             {columns.map((column) => {
               return (
                 <EditableDataTableCell<T>

--- a/src/Components/Organisms/DataTable/LineEditableInPlaceDataTable/LineEditableInPlaceDataTableBody.tsx
+++ b/src/Components/Organisms/DataTable/LineEditableInPlaceDataTable/LineEditableInPlaceDataTableBody.tsx
@@ -20,6 +20,7 @@ const LineEditableInPlaceDataTableBody = <T,>(props: ILineEditableInPlaceDataTab
   const [selectedRows, setSelectedRows] = useState<Record<number, boolean>>({});
 
   const isSelectable = extra.onRowSelect;
+  const isExtended = extra.onRowSelect || extra.computeTotal;
 
   const handleRowClick = (row: T, rowIndex: number) => {
     return extra && extra.onRowClick
@@ -61,14 +62,16 @@ const LineEditableInPlaceDataTableBody = <T,>(props: ILineEditableInPlaceDataTab
             onKeyUp={handleRowClick(row, rowIndex)}
             className={classnames({ pointer: extra && extra.onRowClick, selected: selectedRows[rowIndex] })}
             tabIndex={extra && extra.onRowClick ? 0 : -1}>
-            {isSelectable && (
-              <DataTableCellSelectable
-                handleSelectClick={handleSelectClick(row, rowIndex)}
-                selected={selectedRows[rowIndex]}
-                selectable={(extra.isSelectable ? extra.isSelectable(row, rowIndex) : true) && !extra.editedRowIndex}
-              />
-            )}
-
+            {isExtended &&
+              (isSelectable ? (
+                <DataTableCellSelectable
+                  handleSelectClick={handleSelectClick(row, rowIndex)}
+                  selected={selectedRows[rowIndex]}
+                  selectable={(extra.isSelectable ? extra.isSelectable(row, rowIndex) : true) && !extra.editedRowIndex}
+                />
+              ) : (
+                <td></td>
+              ))}
             {columns.map((column) => {
               return (
                 <LineEditableInPlaceDataTableCell<T>

--- a/src/Components/Organisms/NavBar/NavBar.stories.mdx
+++ b/src/Components/Organisms/NavBar/NavBar.stories.mdx
@@ -121,7 +121,7 @@ Play with NavBar live on [CodeSandbox](https://codesandbox.io/s/sidebar-demo-t4s
               height: '300px',
               padding: '0px 16px',
               overflowX: 'hidden',
-              overflowY: 'scroll',
+              overflowY: 'auto',
               backgroundColor: '#FFF',
             }}>
             <p>
@@ -290,7 +290,7 @@ For layout management, please refer to this [example](https://codesandbox.io/s/s
                 height: '300px',
                 padding: '0px 16px',
                 overflowX: 'hidden',
-                overflowY: 'scroll',
+                overflowY: 'auto',
                 backgroundColor: '#FFF',
               }}>
               <p>

--- a/src/Components/Organisms/SideBar/__test__/SideBarItem.test.tsx
+++ b/src/Components/Organisms/SideBar/__test__/SideBarItem.test.tsx
@@ -64,6 +64,8 @@ describe('SideBarItem Component', () => {
   });
 
   it('SideBarItem handles click on entry in main menu and handles click on submenu', async () => {
+    console.info = jest.fn();
+
     const { container } = render(
       <SideBar backToMenu={'Back to menu'} style={{ height: '600px' }}>
         <SideBarItem label='LABEL' to='/link' dataTestId='PARENT-TEST-ID'>
@@ -79,6 +81,9 @@ describe('SideBarItem Component', () => {
 
     userEvent.click(parentEntry);
     expect(container).toMatchSnapshot();
+
+    expect(console.info).toBeCalledTimes(1);
+    expect(console.info).toBeCalledWith('url pushed:', '/link/link1');
 
     const childEntry = await screen.findByTestId('CHILD-TEST-ID');
     userEvent.click(childEntry);

--- a/src/assets/_sidebar.scss
+++ b/src/assets/_sidebar.scss
@@ -28,7 +28,7 @@
     top: 0;
     left: 0;
     visibility: visible;
-    transition: all 0.5s ease;
+    transition: left 0.5s ease-in-out, visibility 0.5s linear;
   }
 
   .item {
@@ -117,7 +117,7 @@
   &.submenu {
     .sidebar {
       visibility: hidden;
-      transition: all 0.5s ease;
+      transition: left 0.5s ease-in-out, visibility 0.5s linear 0.5s;
     }
   }
 
@@ -133,11 +133,11 @@
     position: fixed;
     box-sizing: border-box;
     visibility: hidden;
-    transition: all 0.5s ease;
+    transition: left 0.5s ease-in-out, visibility 0.5s linear;
 
     &.visible {
       visibility: visible;
-      transition: all 0.5s ease;
+      transition: left 0.5s ease-in-out, visibility 0.5s linear;
     }
   }
 }

--- a/src/assets/_sidebar.scss
+++ b/src/assets/_sidebar.scss
@@ -123,7 +123,7 @@
 
   &.unfixed {
     position: relative;
-    height: fill-available;
+    height: stretch;
     .submenu {
       position: absolute;
     }


### PR DESCRIPTION
Test: Organisms/SideBar capture the url change in the test

Fix: Organisms/SideBar scss should only transition left and visibility instead of all
Fix: Organisms/SideBar use stretch instead of fill-available scss
Fix: Organisms/Datatable ensure the gutter column is displayed when total or select are displayed

Doc: Update README demo URLs